### PR TITLE
Changes to sector and indicators to meet updated USEEIO_API specs 

### DIFF
--- a/doc/data_format.md
+++ b/doc/data_format.md
@@ -147,18 +147,22 @@ optional columns:
 ```
 
 #### Characterization factors
-Characterization factors for impact assessments are stored in CSV files with the
+Characterization factors for indicators are stored in CSV files with the
 following columns:
-
-0. Name of the impact assessment method, e.g. `TRACI`
-1. Name of the impact assessment category, e.g. `Climate change`
-2. Reference unit of the impact assessment category, e.g. `kg CO2 eq.`
-3. Elementary flow name, e.g. `Methane`
-4. Flow category / compartment, e.g. `Air`
-5. Flow sub-category / sub-compartment, e.g. `Unspecified`
-6. Flow unit, e.g. `kg`
-7. Flow UUID
-8. The value of the characterization factor
+```
+Index  Field                                                               Type
+---------------------------------------------------------------------------------------
+0      Group of the indicator, e.g. `Impact Potential`                     string
+1      Code for indicator, e.g. `ACID`                                     string
+2      Reference unit of the indicator, e.g. `kg SO2 eq.`                  string
+3      Elementary flow name, e.g. `Sulfur dioxide`                         string
+4      Flow category / compartment, e.g. `air`                             string
+5      Flow sub-category / sub-compartment, e.g. `unspecified`             string
+6      Flow unit, e.g. `kg`                                                string
+7      Flow UUID                                                           string
+8      Value of the characterization factor                                enumeration
+9      Name of the indicator, e.g. 'Acidification Potential'               string
+```
 
 ### Metadata files
 Metadata files are used when the input-output model is converted to an JSON-LD

--- a/iomb/matio.py
+++ b/iomb/matio.py
@@ -52,16 +52,16 @@ class Export(object):
         self.__write_matrix(U, 'U')
 
         # the data quality matrix of the satellite table: B_dqi
-        #B_dqi = dqi.Matrix.from_sat_table(self.model)
-        #B_dqi.to_csv('%s/B_dqi.csv' % self.folder)
+        B_dqi = dqi.Matrix.from_sat_table(self.model)
+        B_dqi.to_csv('%s/B_dqi.csv' % self.folder)
 
         # the data quality matrix of the direct impacts: D_dqi
-        #D_dqi = B_dqi.aggregate_mmult(C.values, B.values, left=False)
-        #D_dqi.to_csv('%s/D_dqi.csv' % self.folder)
+        D_dqi = B_dqi.aggregate_mmult(C.values, B.values, left=False)
+        D_dqi.to_csv('%s/D_dqi.csv' % self.folder)
 
         # the data quality matrix of the upstream impacts: U_dqi
-        #U_dqi = D_dqi.aggregate_mmult(D, L.values, left=True)
-        #U_dqi.to_csv('%s/U_dqi.csv' % self.folder)
+        U_dqi = D_dqi.aggregate_mmult(D, L.values, left=True)
+        U_dqi.to_csv('%s/U_dqi.csv' % self.folder)
 
         # write matrix indices with meta-data
         self.__write_sectors(A)

--- a/iomb/matio.py
+++ b/iomb/matio.py
@@ -52,16 +52,16 @@ class Export(object):
         self.__write_matrix(U, 'U')
 
         # the data quality matrix of the satellite table: B_dqi
-        B_dqi = dqi.Matrix.from_sat_table(self.model)
-        B_dqi.to_csv('%s/B_dqi.csv' % self.folder)
+        #B_dqi = dqi.Matrix.from_sat_table(self.model)
+        #B_dqi.to_csv('%s/B_dqi.csv' % self.folder)
 
         # the data quality matrix of the direct impacts: D_dqi
-        D_dqi = B_dqi.aggregate_mmult(C.values, B.values, left=False)
-        D_dqi.to_csv('%s/D_dqi.csv' % self.folder)
+        #D_dqi = B_dqi.aggregate_mmult(C.values, B.values, left=False)
+        #D_dqi.to_csv('%s/D_dqi.csv' % self.folder)
 
         # the data quality matrix of the upstream impacts: U_dqi
-        U_dqi = D_dqi.aggregate_mmult(D, L.values, left=True)
-        U_dqi.to_csv('%s/U_dqi.csv' % self.folder)
+        #U_dqi = D_dqi.aggregate_mmult(D, L.values, left=True)
+        #U_dqi.to_csv('%s/U_dqi.csv' % self.folder)
 
         # write matrix indices with meta-data
         self.__write_sectors(A)
@@ -76,12 +76,12 @@ class Export(object):
         path = '%s/sectors.csv' % self.folder
         with open(path, 'w', encoding='utf-8', newline='\n') as f:
             writer = csv.writer(f)
-            writer.writerow(['Index', 'ID', 'Name', 'Code', 'Location'])
+            writer.writerow(['Index', 'ID', 'Name', 'Code', 'Location', 'Description'])
             i = 0
             for sector_key in A.index:
                 sector = self.model.sectors.get(sector_key)
                 writer.writerow([i, sector_key, sector.name, sector.code,
-                                 sector.location])
+                                 sector.location, sector.description])
                 i += 1
 
     def __write_flows(self, B):
@@ -101,13 +101,13 @@ class Export(object):
         path = '%s/indicators.csv' % self.folder
         with open(path, 'w', encoding='utf-8', newline='\n') as f:
             writer = csv.writer(f)
-            writer.writerow(['Index', 'ID', 'Name', 'Code', 'Unit', 'UUID'])
+            writer.writerow(['Index', 'ID', 'Name', 'Code', 'Unit', 'Group'])
             i = 0
             for cat_key in C.index:
                 idx = self.model.ia_table.category_idx.get(cat_key)
                 cat = self.model.ia_table.categories[idx]
-                writer.writerow([i, cat_key, cat.name, '',
-                                 cat.ref_unit, cat.uid])
+                writer.writerow([i, cat_key, cat.name, cat.code,
+                                 cat.ref_unit, cat.group])
                 i += 1
 
 

--- a/iomb/refmap.py
+++ b/iomb/refmap.py
@@ -241,21 +241,23 @@ class ImpactCategory(object):
     """ Describes an impact assessment category. """
 
     def __init__(self):
-        self.method = ''
-        self.name = ''
+        self.group = ''
+        self.code = ''
         self.ref_unit = ''
+        self.name = ''
 
     @staticmethod
     def from_ia_row(csv_row: list):
         ic = ImpactCategory()
-        ic.method = csv_row[0]
-        ic.name = csv_row[1]
+        ic.group = csv_row[0]
+        ic.code = csv_row[1]
         ic.ref_unit = csv_row[2]
+        ic.name = csv_row[9]
         return ic
 
     @property
     def key(self):
-        return as_path(self.method, self.name, self.ref_unit)
+        return as_path(self.group, self.code, self.ref_unit)
 
     @property
     def uid(self):
@@ -299,6 +301,7 @@ class Sector(object):
         s.category = csv_row[2]
         s.sub_category = csv_row[3]
         s.location = csv_row[4]
+        s.description = csv_row[5]
         s.data_quality_entry = Sector.__read_dq_values(csv_row)
         s.csv_row = csv_row
         return s

--- a/iomb/webapi/data.py
+++ b/iomb/webapi/data.py
@@ -15,6 +15,7 @@ class Sector(object):
         self.name = ''
         self.code = ''
         self.location = ''
+        self.description = ''
 
     def as_json_dict(self):
         return {
@@ -23,6 +24,7 @@ class Sector(object):
             'name': self.name,
             'code': self.code,
             'location': self.location
+            'description': self.description
         }
 
 
@@ -31,17 +33,19 @@ class Indicator(object):
     def __init__(self):
         self.id = ''
         self.index = 0
-        self.name = ''
+        self.group = ''
         self.code = ''
         self.unit = ''
+        self.name = ''
 
     def as_json_dict(self):
         return {
             'id': self.id,
             'index': self.index,
-            'name': self.name,
+            'group': self.group,
             'code': self.code,
-            'unit': self.unit
+            'unit': self.unit,
+            'name': self.name
         }
 
 
@@ -155,6 +159,7 @@ def read_sectors(folder: str):
             s.name = row[2]
             s.code = row[3]
             s.location = row[4]
+            s.description = row[5]
             m[s.id] = s
     return m
 
@@ -172,6 +177,7 @@ def read_indicators(folder: str):
             i.name = row[2]
             i.code = row[3]
             i.unit = row[4]
+            i.group = row[5]
             indicators.append(i)
     return indicators
 


### PR DESCRIPTION
These changes were made to accommodate the need to add 'group' to indicators and 'description' to the sectors for the USEEIO-API.  I have tested that the API works after these changes, however one change I noted was the ordering of the indicator fields (i imagine because index is now based on name of the impact category and not the group, and I want to make sure this doesn't cause the SMM Tools to break.
 